### PR TITLE
Add/release landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cartoon-beats-reality-lean-static-gatsby-site",
       "version": "1.0.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "gatsby": "^5.14.1",
         "gatsby-plugin-google-gtag": "^5.14.0",
         "gatsby-plugin-image": "^3.14.0",
@@ -5826,6 +5827,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -20929,6 +20936,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "cli-boxes": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "manual-deploy-deprecated": "gatsby build && gh-pages -d public --no-history"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "gatsby": "^5.14.1",
     "gatsby-plugin-google-gtag": "^5.14.0",
     "gatsby-plugin-image": "^3.14.0",

--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -22,7 +22,9 @@ export default function Layout({ siteTitle, children, smallHeader = false }) {
             alt="mixer logo"
           />
         </Link>
-        <div className="SiteTitle">{siteTitle}</div>
+        <Link to="/">
+          <div className="SiteTitle">{siteTitle}</div>
+        </Link>
       </div>
       <div className="PageContent">
         {children}

--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -1,12 +1,19 @@
 import React from "react"
+import classnames from 'classnames';
 
 import { StaticImage } from "gatsby-plugin-image";
 import { Link } from "gatsby";
 
-export default function Layout({ siteTitle, children }) {
+
+export default function Layout({ siteTitle, children, smallHeader = false }) {
+  const headerClasses = classnames([
+    'Header',
+    smallHeader ? 'Header-small' : null,
+  ]);
+
   return (
     <div>
-      <div className="Header">
+      <div className={headerClasses}>
         <Link to="/">
           <StaticImage
             className="SiteLogo"
@@ -15,7 +22,7 @@ export default function Layout({ siteTitle, children }) {
             alt="mixer logo"
           />
         </Link>
-          <div className="SiteTitle">{siteTitle}</div>
+        <div className="SiteTitle">{siteTitle}</div>
       </div>
       <div className="PageContent">
         {children}

--- a/src/components/releases/HomePageSlantRelease.js
+++ b/src/components/releases/HomePageSlantRelease.js
@@ -21,7 +21,7 @@ function HomePageSlantRelease({ title, artist, coverImage, listenLinks, linkToPa
   }
   
   return (
-    <div className="Release">
+    <div className="Release HomePageSlantRelease">
       <div className="Release-slant"></div>
       <div className="Release-content">
           <div className="Release-info">

--- a/src/components/releases/HomePageSlantRelease.js
+++ b/src/components/releases/HomePageSlantRelease.js
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Link } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
 
-import ListenLinks from "./ListenLinks"
+import ListenIcons from "./ListenIcons"
 
 import "./HomePageSlantRelease.scss"
 
@@ -30,7 +30,7 @@ function HomePageSlantRelease({ title, artist, coverImage, listenLinks, linkToPa
                 {title}</div>
             </MaybeLinkToRelease>
             <div className="Release-info-artist">{artist}</div>
-            <ListenLinks links={listenLinks} />
+            <ListenIcons links={listenLinks} />
           </div>
           <MaybeLinkToRelease>
             <div className="Release-cover">

--- a/src/components/releases/HomePageSlantRelease.scss
+++ b/src/components/releases/HomePageSlantRelease.scss
@@ -26,7 +26,7 @@
       background-color: globals.$dark-bg-b;
       transform: skewY(+1.5deg);    
     }
-    .ListenLinks {
+    .ListenIcons {
       justify-content: flex-start;
     }
 
@@ -41,7 +41,7 @@
 
 
   &:nth-child(odd) {
-    .ListenLinks {
+    .ListenIcons {
       justify-content: flex-end;
     }
     .Release-slant {

--- a/src/components/releases/HomePageSlantRelease.scss
+++ b/src/components/releases/HomePageSlantRelease.scss
@@ -1,9 +1,7 @@
 @use '../../pages/_globals.scss';
+@use './Release-base.scss';
 
-.Release {
-  @include globals.full-width;
-  position: relative; /* so can position skewed background div */
-
+.Release.HomePageSlantRelease {
   .Release-slant {
     position: absolute;
     left: 0;
@@ -16,34 +14,20 @@
   }
   
   .Release-content {
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 1em 0;
-    color: globals.$text;
-  
     .Release-info {
       text-align: right;
       margin: 1em;
       width: 30%;
-  
-      .Release-info-title {
-        font-size: 140%;
-        font-weight: bold;
-        // Reset link color to regular text colour.
-        color: globals.$text;
-      }
-      
-      .Release-info-artist {
-        font-size: 120%;
-      }    
-    };
+    }
   }
 
   &:nth-child(even) {
     .Release-slant {
       background-color: globals.$dark-bg-b;
       transform: skewY(+1.5deg);    
+    }
+    .ListenLinks {
+      justify-content: flex-start;
     }
 
     .Release-content {
@@ -55,11 +39,32 @@
     }
   }
 
+
   &:nth-child(odd) {
+    .ListenLinks {
+      justify-content: flex-end;
+    }
     .Release-slant {
       background-color: globals.$dark-bg-a;
       transform: skewY(-1.5deg);    
     }
   }
+
+  .gatsby-image-wrapper, img {
+    max-width: 200px;
+  }
+
+  @media only screen and (min-width: globals.$small) {
+    .gatsby-image-wrapper, img {
+      max-width: 250px;
+    }  
+  }
+
+  @media only screen and (min-width: globals.$medium) {
+    .gatsby-image-wrapper, img {
+      max-width: 300px;
+    }
+  }
+
 }
 

--- a/src/components/releases/ListenButtons.js
+++ b/src/components/releases/ListenButtons.js
@@ -1,0 +1,54 @@
+import * as React from "react"
+
+import "./ListenButtons.scss"
+
+function storeIdToLabel(storeName) {
+  if (!storeName) {
+    return ''
+  };
+
+  if (storeName === 'apple') {
+    return 'Apple Music';
+  }
+  if (storeName === 'soundcloud') {
+    return 'SoundCloud';
+  }
+  if (storeName === 'youtube') {
+    return 'YouTube';
+  }
+
+  return storeName.charAt(0).toUpperCase() + storeName.slice(1);
+}
+
+// url - listen link for store
+// store - one of beatport, spotify, apple, amazon, youtube, bandcamp, 
+// TODO enforce this with TypeScript?
+function ListenButton({ store, url }) {
+  let labelPrefix = 'Stream on';
+  if (store === 'bandcamp') {
+    labelPrefix = 'Stream & buy at';
+  }
+  if (store === 'beatport') {
+    labelPrefix = 'Blend at';
+  }
+
+  return (<a href={url}>
+    <span className={`icon-${store}`}></span>
+    <label>{labelPrefix} {storeIdToLabel(store)}</label>
+  </a>);
+}
+
+function ListenButtons({ links }) {
+  let listenElements = Object.keys(links).map(store => {
+    const url = links[store];
+    return (url && <ListenButton key={store} store={store} url={url} />);
+  });
+  
+  return (
+    <div className="ListenButtons">
+      {listenElements}
+    </div>
+  );
+}
+
+export default ListenButtons;

--- a/src/components/releases/ListenButtons.scss
+++ b/src/components/releases/ListenButtons.scss
@@ -13,7 +13,7 @@
   a {
     color: globals.$dark-bg-b;
     background-color: globals.$link;
-    padding: 0.2em 0.8em 0.2em 0.4em;
+    padding: 0.35em 0.8em 0.4em 0.3em;
     border-radius: 1em;
   }
 
@@ -30,7 +30,6 @@
   // Apple icon can be a bit bigger and higher because the leaf doesn't really affect centre of gravity.
   .icon-apple {
     position: relative;
-    font-size: 105%;
-    top: -2px;
+    top: -1px;
   }
 }

--- a/src/components/releases/ListenButtons.scss
+++ b/src/components/releases/ListenButtons.scss
@@ -1,0 +1,36 @@
+@use '../../pages/_globals.scss';
+
+
+.ListenButtons {
+  margin: 1.5em 0 0.2em;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.8em;
+  align-items: center;
+  
+  a {
+    color: globals.$dark-bg-b;
+    background-color: globals.$link;
+    padding: 0.2em 0.8em 0.2em 0.4em;
+    border-radius: 1em;
+  }
+
+  a span::before {
+    font-size: 110%;
+  }
+
+  // Amazon icon is not properly aligned IMO.
+  .icon-amazon {
+    position: relative;
+    top: 2px;
+  }
+
+  // Apple icon can be a bit bigger and higher because the leaf doesn't really affect centre of gravity.
+  .icon-apple {
+    position: relative;
+    font-size: 105%;
+    top: -2px;
+  }
+}

--- a/src/components/releases/ListenIcons.js
+++ b/src/components/releases/ListenIcons.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import "./ListenLinks.scss"
+import "./ListenIcons.scss"
 
 // url - listen link for store
 // store - one of beatport, spotify, apple, amazon, youtube, bandcamp, 
@@ -12,17 +12,17 @@ function ListenIcon({ store, url }) {
   </a>);
 }
 
-function ListenLinks({ links }) {
+function ListenIcons({ links }) {
   let listenElements = Object.keys(links).map(store => {
     const url = links[store];
     return (url && <ListenIcon key={store} store={store} url={url} />);
   });
   
   return (
-    <div className="ListenLinks">
+    <div className="ListenIcons">
       {listenElements}
     </div>
   );
 }
 
-export default ListenLinks;
+export default ListenIcons;

--- a/src/components/releases/ListenIcons.scss
+++ b/src/components/releases/ListenIcons.scss
@@ -1,7 +1,7 @@
 @use '../../pages/_globals.scss';
 
 
-.ListenLinks {
+.ListenIcons {
   margin-top: 0.5em;
   font-size: 120%;
   color: globals.$link;

--- a/src/components/releases/ListenLinks.scss
+++ b/src/components/releases/ListenLinks.scss
@@ -1,18 +1,12 @@
 @use '../../pages/_globals.scss';
 
-// This is a little coupled to .Release, since we're using release children for alternating layout.
-.Release {
-  &:nth-child(odd) .ListenLinks {
-    // When cover image is on right, if links wrap, they should be right-aligned.
-    justify-content: flex-end;
-  }
-}
 
 .ListenLinks {
   margin-top: 0.5em;
   font-size: 120%;
   color: globals.$link;
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 0.1em 0.5em;
   

--- a/src/components/releases/Release-base.scss
+++ b/src/components/releases/Release-base.scss
@@ -1,0 +1,32 @@
+@use '../../pages/_globals.scss';
+
+.Release {
+  @include globals.full-width;
+  position: relative; /* so can position skewed background div */
+  
+  .Release-content {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 1em 0;
+    color: globals.$text;
+  
+    .Release-info {
+      text-align: center;
+      margin: 1em;
+      width: 100%;
+  
+      .Release-info-title {
+        font-size: 140%;
+        font-weight: bold;
+        // Reset link color to regular text colour.
+        color: globals.$text;
+      }
+      
+      .Release-info-artist {
+        font-size: 120%;
+      }    
+    };
+  }
+}
+

--- a/src/components/releases/ReleaseList.js
+++ b/src/components/releases/ReleaseList.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import Release from './Release';
+import HomePageSlantRelease from './HomePageSlantRelease';
 
 import "./ReleaseList.scss"
 
@@ -10,7 +10,7 @@ import "./ReleaseList.scss"
 // image
 function ReleaseList({ releases }) {
   const rows = releases.map(( releaseInfo ) => ( 
-    <Release
+    <HomePageSlantRelease
       key={releaseInfo.id}
       coverImage={releaseInfo.image} 
       title={releaseInfo.title}

--- a/src/components/releases/VerticalStackRelease.js
+++ b/src/components/releases/VerticalStackRelease.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Link } from "gatsby"
+
 import { GatsbyImage } from "gatsby-plugin-image"
 
 import ListenIcons from "./ListenIcons"

--- a/src/components/releases/VerticalStackRelease.js
+++ b/src/components/releases/VerticalStackRelease.js
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { Link } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+
+import ListenLinks from "./ListenLinks"
+
+import "./VerticalStackRelease.scss"
+
+
+function VerticalStackRelease({ title, artist, coverImage, listenLinks, linkToPath }) {
+  return (
+    <div className="Release VerticalStackRelease">
+      <div className="Release-content">
+        <div className="Release-info">
+          <div className="Release-info-title">{title}</div>
+          <div className="Release-info-artist">{artist}</div>
+          <ListenLinks links={listenLinks} />
+        </div>
+        <div className="Release-cover">
+          { coverImage && <GatsbyImage 
+            image={coverImage} 
+            alt={title}
+            /> }
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default VerticalStackRelease;

--- a/src/components/releases/VerticalStackRelease.js
+++ b/src/components/releases/VerticalStackRelease.js
@@ -2,19 +2,20 @@ import * as React from "react"
 import { Link } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
 
-import ListenLinks from "./ListenLinks"
+import ListenIcons from "./ListenIcons"
+import ListenButtons from "./ListenButtons"
 
 import "./VerticalStackRelease.scss"
 
 
-function VerticalStackRelease({ title, artist, coverImage, listenLinks, linkToPath }) {
+function VerticalStackRelease({ title, artist, coverImage, listenLinks, blurb }) {
   return (
     <div className="Release VerticalStackRelease">
       <div className="Release-content">
         <div className="Release-info">
           <div className="Release-info-title">{title}</div>
           <div className="Release-info-artist">{artist}</div>
-          <ListenLinks links={listenLinks} />
+          <ListenIcons links={listenLinks} />
         </div>
         <div className="Release-cover">
           { coverImage && <GatsbyImage 
@@ -22,6 +23,8 @@ function VerticalStackRelease({ title, artist, coverImage, listenLinks, linkToPa
             alt={title}
             /> }
         </div>
+        <ListenButtons links={listenLinks} />
+        {blurb && (<div className="Release-blurb">{blurb}</div>)}
       </div>
     </div>
   )

--- a/src/components/releases/VerticalStackRelease.scss
+++ b/src/components/releases/VerticalStackRelease.scss
@@ -6,5 +6,10 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    .Release-blurb {
+      padding: 1em;
+      text-align: center;
+    }
   }
 }

--- a/src/components/releases/VerticalStackRelease.scss
+++ b/src/components/releases/VerticalStackRelease.scss
@@ -1,0 +1,10 @@
+@use '../../pages/_globals.scss';
+@use './Release-base.scss';
+
+.Release.VerticalStackRelease {
+  .Release-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}

--- a/src/components/releases/index.js
+++ b/src/components/releases/index.js
@@ -1,8 +1,10 @@
 import ReleaseList from './ReleaseList';
-import Release from './Release';
+import HomePageSlantRelease from './HomePageSlantRelease';
+import VerticalStackRelease from './VerticalStackRelease';
 
 export {
-  Release
+  HomePageSlantRelease,
+  VerticalStackRelease
 };
 
 export default ReleaseList;

--- a/src/data/releases.yml
+++ b/src/data/releases.yml
@@ -13,8 +13,8 @@
     spotify: https://open.spotify.com/album/2lErQXsyS9Nfak5HNFxPGW
     apple: https://music.apple.com/nz/album/galley-listing-single/1827314937
   blurb:
-    A new riff on Sinking Galley, my ancient undersea collaboration with Kathia Rudametkin. 
-    Galley Listing takes place centuries prior to Sinking Galley – the ship’s in rough seas and about to capsize!
+    "Galley Listing is a dark dub techno riff on Sinking Galley, Haszari's ancient undersea collaboration with Kathia Rudametkin. 
+    Galley Listing takes place centuries prior to Sinking Galley – the ship's in rough seas and about to capsize!"
 
 
 - catalogueNumber: "CBR015b"

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -20,7 +20,7 @@ a {
   cursor: pointer;
 }
 
-.Header, .PageContent {
+.PageContent {
   max-width: 400px;
   margin: auto;
   font-size: 0.8em;
@@ -53,19 +53,52 @@ a {
 .Header {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 1em;
   padding: 1em 1em 0.5em;
     
   .SiteLogo {
-    width: 7em;
+    width: 3em;
   };
-
+  
   .SiteTitle {
     font-family: 'Hedvig Letters Serif';
-    font-size: 2em;
+    font-size: 1.4em;
     font-weight: bold;
   }
+  
+  @media only screen and (min-width: globals.$small) {
+    justify-content: space-evenly;
+    .SiteLogo {
+      width: 7em;
+    };
+    .SiteTitle {
+      font-size: 2em;
+    }
+  }
 }
+
+.Header.Header-small {
+  justify-content: space-between;
+
+  .SiteLogo {
+    width: 2em;
+  };
+  .SiteTitle {
+    font-size: 1em;
+  }
+
+  @media only screen and (min-width: globals.$small) {
+    justify-content: space-evenly;
+    .SiteLogo {
+      width: 3em;
+    };
+    .SiteTitle {
+      font-size: 1.4em;
+    }
+  }
+}
+
 
 .Footer {
   width: 100%;

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -56,6 +56,11 @@ a {
   justify-content: center;
   gap: 1em;
   padding: 1em 1em 0.5em;
+
+  a {
+    // Override header links to look like regular text.
+    color: globals.$text;
+  }
     
   .SiteLogo {
     width: 3em;

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -28,7 +28,7 @@ a {
   .gatsby-image-wrapper, img {
     width: 100%;
     height: auto;
-    max-width: 200px;
+    max-width: 70vw;
   }
 
   @media only screen and (min-width: globals.$small) {
@@ -36,7 +36,7 @@ a {
     font-size: 0.8em;
 
     .gatsby-image-wrapper, img {
-      max-width:250px;
+      max-width: 60vw;
     }  
   }
 
@@ -45,7 +45,7 @@ a {
     font-size: 1.2em;
 
     .gatsby-image-wrapper, img {
-      max-width:300px;
+      max-width: max(50vw, 400px);
     }
   }
 }

--- a/src/pages/releases/{releasesYaml.title}.js
+++ b/src/pages/releases/{releasesYaml.title}.js
@@ -5,7 +5,7 @@ import { graphql } from 'gatsby';
 import { getImage } from "gatsby-plugin-image"
 
 import Layout from "../../components/layout"
-import { Release } from "../../components/releases"
+import { VerticalStackRelease } from "../../components/releases"
 
 // import "../fonts.scss"
 // import "../index.scss"
@@ -25,13 +25,14 @@ const Page = ({data}) => {
 
   return (
     <Layout siteTitle={data.site.siteMetadata.title}>
-      <Release
+      <VerticalStackRelease
         key={releaseInfo.id}
         coverImage={releaseInfo.image} 
         title={releaseInfo.title}
         artist={releaseInfo.artist}
         listenLinks={releaseInfo.listenLinks}
       />
+      <p>{releaseInfo.blurb}</p>
     </Layout>
   )
 }
@@ -51,6 +52,7 @@ export const query = graphql`query($id: String) {
     title
     cover
     releaseDate
+    blurb
     listenLinks {
       bandcamp
       apple

--- a/src/pages/releases/{releasesYaml.title}.js
+++ b/src/pages/releases/{releasesYaml.title}.js
@@ -20,9 +20,8 @@ const Page = ({data}) => {
   );
   releaseInfo.image = getImage(imageNode);
 
-
   return (
-    <Layout siteTitle={data.site.siteMetadata.title}>
+    <Layout siteTitle={data.site.siteMetadata.title} smallHeader={true}>
       <VerticalStackRelease
         key={releaseInfo.id}
         coverImage={releaseInfo.image} 

--- a/src/pages/releases/{releasesYaml.title}.js
+++ b/src/pages/releases/{releasesYaml.title}.js
@@ -7,8 +7,6 @@ import { getImage } from "gatsby-plugin-image"
 import Layout from "../../components/layout"
 import { VerticalStackRelease } from "../../components/releases"
 
-// import "../fonts.scss"
-// import "../index.scss"
 import "../../fontello/css/fontawesome-musicstores.css"
 
 const Page = ({data}) => {
@@ -31,8 +29,8 @@ const Page = ({data}) => {
         title={releaseInfo.title}
         artist={releaseInfo.artist}
         listenLinks={releaseInfo.listenLinks}
+        blurb={releaseInfo.blurb}
       />
-      <p>{releaseInfo.blurb}</p>
     </Layout>
   )
 }


### PR DESCRIPTION
Add a new more responsive "link in profile" style landing page for releases. It supports a text blurb and shows listen links as icons AND larger buttons. The release page header is smaller, to focus more on the content, and has been tweaked to be more responsive on main page.


It looks like this:

<img width="417" height="597" alt="Screenshot 2025-07-19 at 2 24 06 PM" src="https://github.com/user-attachments/assets/684319e1-1b39-4bef-b412-ae088f04352a" />
